### PR TITLE
Add duration parameter

### DIFF
--- a/cliOptions.cpp
+++ b/cliOptions.cpp
@@ -53,6 +53,7 @@ static struct option long_options[] =
     {"qmin-max", required_argument, 0, 'q'},
     {"key-int", required_argument, 0, 'k'},
     {"output-list",   required_argument, 0, 'o'},
+    {"duration",   required_argument, 0, 't'},
     {0, 0, 0, 0}
 };
 
@@ -69,8 +70,9 @@ static  void help()
   printf( "   --size,-s      - video source size ( default = 640x480 )\n" );
   printf( "   --size-out,-z  - H264 video size output ( default = same as input )\n" );
   printf( "   --qmin-max,-q  - encoding quality ( default = -q 20,30 )\n" );
-  printf( "   --key-int,-k   - key frmae interval ( default = 5 )\n" );
+  printf( "   --key-int,-k   - key frame interval ( default = 5 )\n" );
   printf( "   --output-list,-o - list of output FIFO's ( default = None, example: -o /tmp/o1.h264, /tmp/o2.h264, /tmp/o3.nv12 )\n" );
+  printf( "   --duration,-t - duration of capture ( default = 0, example: -t 120 )\n" );
   printf( "\n\n" );
 }
 
@@ -87,6 +89,7 @@ static  void dumpOptions( CmdLineOptions & options )
   printf( "qMin       [%d]\n", options.qMin );
   printf( "qMax       [%d]\n", options.qMax );
   printf( "KeyInterval[%d]\n", options.keyInterval );
+  printf( "Duration   [%d]\n", options.duration );
 
   for( size_t i = 0; i < options.outFifos.size(); i++ )
   {
@@ -104,7 +107,7 @@ int processCmdLineOptions( CmdLineOptions & options, int argc, char **argv )
    {
 	  /* getopt_long stores the option index here. */
 	  int option_index = 0;
-	  c = getopt_long (argc, argv, "h:i:b:r:s:z:q:o:k:", long_options, &option_index);
+	  c = getopt_long (argc, argv, "h:i:b:r:t:s:z:q:o:k:", long_options, &option_index);
 	  /* Detect the end of the options. */
 	  if (c == -1)
 	    break;
@@ -122,6 +125,10 @@ int processCmdLineOptions( CmdLineOptions & options, int argc, char **argv )
 	    case 'r':
 	      options.fps = atoi( optarg );
 	      break;
+
+            case 't':
+              options.duration = atoi( optarg );
+              break;
 
 	    case 'k':
 	      options.keyInterval = atoi( optarg );

--- a/cliOptions.h
+++ b/cliOptions.h
@@ -34,6 +34,7 @@ Inputs:
 -z <WxH> - output dim.
 -q <Min,Max>
 -o <x.h264>,<z.nv12>
+-t <secs> - duration of capture
 */
 
 struct CmdLineOptions
@@ -48,6 +49,7 @@ struct CmdLineOptions
   size_t      qMin;
   size_t      qMax;
   size_t      keyInterval;
+  unsigned int duration;
   std::vector< std::string > outFifos;
 };
 

--- a/videoenc.cpp
+++ b/videoenc.cpp
@@ -50,6 +50,8 @@ unsigned int input_size  = mwidth * (mheight + mheight / 2);
 int Y_size   = mwidth * mheight;
 int UV_size  = mwidth * mheight / 2;
 
+unsigned int duration = 0;
+
 int g_msDelay = 0;
 
 VencHeaderData  sps_pps_data;
@@ -436,6 +438,7 @@ void handle_int(int n)
 
 int main( int argc, char **argv )
 {
+   time_t time_start, time_now;
    int err = 0;
    err = processCmdLineOptions( g_options, argc, argv );
    VideoEncoder* pVideoEnc = NULL;
@@ -447,6 +450,7 @@ int main( int argc, char **argv )
     mheight = g_options.height;
     src_width  = mwidth;
     src_height = mheight;
+    duration = g_options.duration;
 
     dst_width  = g_options.width_out;
     dst_height = g_options.height_out;
@@ -609,15 +613,19 @@ int main( int argc, char **argv )
      if (err || !venc_cxt->thread_enc_id) {
 	printf("Create thread_enc_id fail !\n");
      }
-
+     // This is right after the encoding thread has started, get the time to calculate the duration
+     time(&time_start);
      struct sigaction sigact;
      memset(&sigact, 0, sizeof(sigact));
      sigact.sa_handler = handle_int;
-     while( !quit && venc_cxt->mstart )
+     time(&time_now);
+     while( !quit && venc_cxt->mstart && ((duration > 0 && difftime(time_now, time_start) < duration) || duration == 0))
      {
         if( cameraOn && !venc_cxt->CameraDevice->getState( venc_cxt->CameraDevice ) )
 	    break;
   	sleep( 1 );
+        // Get current time to check whether we need to stop to stay within the specified duration
+        time(&time_now);
      }
      pthread_mutex_lock( &g_mutex );
      pthread_cond_signal( &g_cond );


### PR DESCRIPTION
This PR is adding a -t parameter to allow for a stream duration setting. Of course this implementation is not 100% accurate in that it doesn't produce a stream of the specific duration. Rather the given number of seconds is the lower bound of the actual value.
