### PR TITLE
Add A13/A8 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libyuv"]
+	path = libyuv
+	url = https://chromium.googlesource.com/libyuv/libyuv

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SRCDIRS:=. Camera watermark
 
 CFLAGS =-Wall -O3 -ldl -pthread -std=c++11
 
-INCLUDES:=$(foreach dir,$(SRCDIRS),-I$(dir)) -I.
+INCLUDES:=$(foreach dir,$(SRCDIRS),-I$(dir)) -I. -I./libyuv/include
 
 SRCCS=$(foreach dir,$(SRCDIRS),$(wildcard $(dir)/*.c))
 SRCPPS=$(foreach dir,$(SRCDIRS),$(wildcard $(dir)/*.cpp))
@@ -38,7 +38,12 @@ SRCPPS=$(foreach dir,$(SRCDIRS),$(wildcard $(dir)/*.cpp))
 LIBOBJ=$(addprefix $(BUILDPATH)/, $(addsuffix .o, $(basename $(SRCCS)))) 
 LIBOBJ+=$(addprefix $(BUILDPATH)/, $(addsuffix .o, $(basename $(SRCPPS)))) 
 
-LDFLAGS= -lvencoder -lcdx_base -lMemAdapter -lVE -L/usr/local/lib/cedarx -ldl -lm -lpthread
+LDFLAGS= -ldl -lm -lpthread ./libyuv/libyuv.a
+ifeq ($(shell pkg-config --exists cedarx; echo $$?),0)
+LDFLAGS += $(shell pkg-config --libs cedarx)
+else
+LDFLAGS += -lvencoder -lcdx_base -lMemAdapter -lVE -L/usr/local/lib/cedarx
+endif
 
 all: $(TARGET)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This test uses Armbian OS for H3, version 3.4.110+
 Compilation is simple, grab the sources and:
 
 
-First, install the provided BLOBs. They have been packaged in the "blobs" directory of the repository.
+1) install the provided BLOBs. They have been packaged in the "blobs" directory of the repository.
 
 Go to:
 
@@ -54,25 +54,31 @@ Go to:
 	tar xzvf [root_of_git_repo]/blobs/cedarx_blobs.tar.gz
 
 
-Now, you need to config the ".so" libraries, adding:
+2) you need to config the ".so" libraries, adding:
 
     nano "/etc/ld.so.conf.d/cedarx.conf",  and the content below:
 
     # Cedarx configuration
     /usr/local/lib/cedarx
 
-and once you save this file:
+3) Once you save this file:
 
     ldconfig
     
-Once this setup is done:
+4) Once this setup is done:
 
     make
-
+    
 
 This should compile and link, and you should get an utility called: "videoenc".
 
 NOTE: at this stage, no "install" target, but maybe added later.
+
+For C.H.I.P running Debian Jessie, Linux 4.4, Replace steps 1-3 above with:
+
+	1) Install and load sunxi-cedar-mod.ko (https://github.com/mzakharo/sunxi_cedar) driver
+
+	2) Build and install CedarX (https://github.com/mzakharo/CedarX-12.06.2015) library
 
 
 Testing the Encoder Demo

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ Go to:
 
     ldconfig
     
-4) Once this setup is done:
+4) Build libyuv
+
+	git submodule init
+	git submodule update
+	cd libyuv/; make -f linux.mk libyuv.a; cd ../
+    
+5) Once this setup is done:
 
     make
     

--- a/videoenc.cpp
+++ b/videoenc.cpp
@@ -33,6 +33,7 @@
 #include <string>
 
 #include "aw/vencoder.h"
+#include "libyuv.h"
 
 #include "CameraSource.h"
 #include "water_mark.h"
@@ -368,8 +369,11 @@ int CameraSourceCallback(void *cookie,  void *data)
 	//nPts = 9*(nPts/10);
 	//input_buffer.nPts  = nPts;
 	if( CameraDevice->isYUYV ) {
-	  
-	    v4lconvert_yuyv_to_yuv420((const unsigned char *)buffer, (unsigned char *)input_buffer.pAddrVirY, (unsigned char *)input_buffer.pAddrVirC, mwidth, mheight, 0 );
+
+        libyuv::YUY2ToNV12(buffer, mwidth * 2,
+                input_buffer.pAddrVirY, mwidth,
+                input_buffer.pAddrVirC, mwidth,
+                mwidth, mheight);
         }
 	else {
 	      //LOGD("Cam - convert from yuyv1 =%d\n", Y_size );
@@ -514,7 +518,7 @@ int main( int argc, char **argv )
 	
     baseConfig.nDstWidth    = dst_width;
     baseConfig.nDstHeight   = dst_height;
-    baseConfig.eInputFormat = VENC_PIXEL_YUV420P;
+    baseConfig.eInputFormat = VENC_PIXEL_YUV420SP;
     //baseConfig.eInputFormat = VENC_PIXEL_YUYV422;
 	
     bufferParam.nSizeY = baseConfig.nInputWidth*baseConfig.nInputHeight;


### PR DESCRIPTION
Tested on C.H.I.P platform.  
A13/R8 ISP does not support VENC_PIXEL_YUV420P,  hence the use of NEON optimized libyuv library for YUY2 -> NV12 conversion.